### PR TITLE
Update to newer 'ruby setup' action and run CI on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,9 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install bundler
-        run: gem install bundler
-      - name: Run bundler
-        run: bundle install --jobs 4 --retry 3
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Run Rake
         run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,6 +16,6 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
       - name: Run Rake
         run: bundle exec rake


### PR DESCRIPTION
The github action we're using for that appears to be broken, and recommends switching to this one (see https://github.com/ngrok/ngrok-api-ruby/pull/10)